### PR TITLE
[DSW-1857] Update deprecated set-output in GitHub CI

### DIFF
--- a/.github/workflows/pot.yml
+++ b/.github/workflows/pot.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
           GITHUB_TAG=`echo $GITHUB_REF | cut -d/ -f3`
           if [[ $GITHUB_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::set-output name=is_prerelease::false"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=is_prerelease::true"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: '[release] Create & Upload Artifacts'


### PR DESCRIPTION
Based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/